### PR TITLE
fix: banner image stretch and duplicate profile button on mobile

### DIFF
--- a/apps/frontend/src/components/banner.tsx
+++ b/apps/frontend/src/components/banner.tsx
@@ -12,12 +12,15 @@ import { ProfileButton } from '@/components/profile-button';
  */
 export function Banner() {
   return (
-    <header aria-label="The Brandy Hall Archives site banner" className="relative w-full h-[315px] shrink-0 mb-3 shadow-[0_4px_12px_rgba(0,0,0,0.25)] border-b border-amber-800/30">
+    <header
+      aria-label="The Brandy Hall Archives site banner"
+      className="relative w-full shrink-0 mb-3 shadow-[0_4px_12px_rgba(0,0,0,0.25)] border-b border-amber-800/30 flex items-center justify-center py-6"
+    >
       {/* Full-bleed hero background image + gradient overlay */}
       <HeroBackground />
 
       {/* ProfileButton — client component, floated to top-right */}
-      <div className="absolute right-4 top-4 z-20 sm:right-6 sm:top-6">
+      <div className="absolute right-4 top-4 z-20 sm:right-6 sm:top-6 hidden lg:block">
         <ProfileButton />
       </div>
     </header>

--- a/apps/frontend/src/components/hero-background.tsx
+++ b/apps/frontend/src/components/hero-background.tsx
@@ -2,15 +2,14 @@ import Image from 'next/image';
 
 export function HeroBackground() {
   return (
-    <div className="w-full h-full">
-      <Image
-        src="/BHA_Alpha_Logo_Resized.png"
-        alt="The Brandy Hall Archives"
-        width={1387}
-        height={304}
-        className="w-full h-full object-contain block"
-        priority
-      />
-    </div>
+    <Image
+      src="/BHAalpha.png"
+      alt="The Brandy Hall Archives"
+      width={2494}
+      height={964}
+      className="w-4/5 sm:w-3/5 h-auto block"
+      style={{ maxWidth: '800px' }}
+      priority
+    />
   );
 }


### PR DESCRIPTION
The resized banner PNG (BHA_Alpha_Logo_Resized.png) had strange dimensions (1387x304 vs the original's 2494x964), which was the cause of the horizontal stretching. Switched to BHAalpha.png directly. 

Also noticed the profile button was rendering twice on mobile screen sizes (one in banner and one in mobile nav header). Hid the banner one below the "lg" breakpoint to match where the mobile header appears. This way the banner image isn't occluded.

Tested: types pass, targeted lint clean, visually verified on desktop and iPhone 12 sim.