### PR TITLE
fix: profile delete crashing on empty response body

### DIFF
--- a/apps/frontend/src/app/api/profiles/[id]/route.ts
+++ b/apps/frontend/src/app/api/profiles/[id]/route.ts
@@ -86,13 +86,12 @@ export async function DELETE(request: NextRequest, { params }: { params: Promise
       },
     });
 
-    const data = await response.json();
-
     if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
       return NextResponse.json({ message: data.error || 'Failed to delete profile' }, { status: response.status });
     }
 
-    return NextResponse.json(data);
+    return new NextResponse(null, { status: 204 });
   } catch (error) {
     console.error('Profile deletion error:', error);
     return NextResponse.json({ message: 'An error occurred while deleting the profile' }, { status: 500 });


### PR DESCRIPTION
The backend returns 204 No Content on successful profile deletion, but the API route was calling response.json() before checking response.ok. Threw a SyntaxError and showed up as a 500 in logs, which is why "an error occurred" was showing instead of the redirect.

Moved response.json() inside the !response.ok block with a catch, returning 204 instead of forwarding the empty body.

Tested: create profile -> delete -> 204 -> redirects to /archive cleanly